### PR TITLE
Minor fixes

### DIFF
--- a/steps/0/README.md
+++ b/steps/0/README.md
@@ -22,7 +22,7 @@ kubectl get cs
 ```
 + Get components from kubernetes
 ```bash
-kubectl get pod --n kube-system
+kubectl get pod -n kube-system
 ```
 
 ## Install a self contained registry

--- a/steps/0/registry.yaml
+++ b/steps/0/registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: kube-registry-v0
@@ -55,7 +55,7 @@ spec:
   - name: registry
     port: 5000
     protocol: TCP
-  ClusterIP: 10.101.91.182
+  clusterIP: 10.101.91.182
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet


### PR DESCRIPTION
I found that --n does not work, should be --namespace or -n. 

Also, I am learning but I had to change registry.yaml as shown to make it work

kubectl version output:
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.0", GitCommit:"925c127ec6b946659ad0fd596fa959be43f0cc05", GitTreeState:"clean", BuildDate:"2017-12-15T21:07:38Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"windows/amd64"}
Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.0", GitCommit:"0b9efaeb34a2fc51ff8e4d34ad9bc6375459c4a4", GitTreeState:"clean", BuildDate:"2017-11-29T22:43:34Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"linux/amd64"}
```